### PR TITLE
Fix synctex inverse_search_command

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -171,13 +171,14 @@ Synctex
 - Press :code:`f4` to toggle synctex mode (:code:`toggle_synctex` command). While in this mode, right clicking on any text opens the corresponding :code:`tex` file in the appropriate location.
 - You can configure the synctex inverse search command using :code:`inverse_search_command` config in :code:`prefs.config` . Here is an example for VsCode (%1 stands for the name of the file and %2 stands for the line number in the file)::
 
-      inverse_search_command "C:\path\to\vscode\Code.exe" -r -g %1:%2
+      inverse_search_command "C:\path\to\vscode\Code.exe" "C:\path\to\vscode\resources\app\out\cli.js" --ms-enable-electron-run-as-node -r -g "%1:%2"
+      
 - Here is a sample configuration for latex workshop in VSCode::
 
    "latex-workshop.view.pdf.external.synctex.command": "C:\\path\\to\\sioyek.exe",
    "latex-workshop.view.pdf.external.synctex.args": [
    "--inverse-search",
-    "\"C:\\path\\to\\vscode\\Code.exe\" -r -g %1:%2",
+    "\"C:\\path\\to\\vscode\\Code.exe\" \"C:\\path\\to\\vscode\\resources\\app\\out\\cli.js\" --ms-enable-electron-run-as-node -r -g \"%1:%2\"",
     "--reuse-instance",
     "--forward-search-file",
     "%TEX%",


### PR DESCRIPTION
Original synctex inverse_search_command does not work for VSCode.
I adapted the command from the [LaTeX-Workshop Wiki for SumatraPDF](https://github.com/James-Yu/LaTeX-Workshop/wiki/View#synctex). Now, it works flawlessly. I thus updated the documentation.