### PR TITLE
Do not download intersphinx inventories

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,18 +15,10 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'sphinx.ext.intersphinx',
     'sphinx.ext.autosectionlabel',
 ]
 
 autosectionlabel_prefix_document = True
-
-
-intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
-}
-intersphinx_disabled_domains = ['std']
 
 templates_path = ['_templates']
 


### PR DESCRIPTION
This prevents unwanted network connections during build. Intersphinx links are not currently used in the documentation.